### PR TITLE
Improve compare_invbal error handling

### DIFF
--- a/backend/compare_invbal.py
+++ b/backend/compare_invbal.py
@@ -15,6 +15,9 @@ def register_routes(app):
         if not conv_f or not eds_f or not part_col or not value_col:
             return jsonify(message="Missing one of: conv_file, eds_file, eds_part_col, value_col"), 400
 
+        differences = []  # initialize for error handling
+        matched_count = 0
+
         try:
             conv_df = pd.read_csv(conv_f, encoding='windows-1252', skiprows=8, dtype=str)
             eds_df  = pd.read_csv(eds_f, encoding='windows-1252', skiprows=8, dtype=str)
@@ -68,5 +71,8 @@ def register_routes(app):
 
         except Exception as ex:
             logger.exception("[compare_inv_bal] Unexpected error")
-            print(f"[compare_inv_bal] {len(differences)} differences found out of {matched_count} matches")
+            if matched_count:
+                logger.error(
+                    f"[compare_inv_bal] {len(differences)} differences found out of {matched_count} matches"
+                )
             return jsonify(message=str(ex)), 500


### PR DESCRIPTION
## Summary
- initialize `differences` and `matched_count` before processing
- conditionally log mismatch count in error handler

## Testing
- `pip install -r requirements.txt`
- `python - <<'PY'
import sys
sys.path.insert(0, 'backend')
import main
app = main.app
with app.test_client() as client:
    data = {
        'conv_file': (open('/tmp/test_data/conv_bad.csv', 'rb'), 'conv.csv'),
        'eds_file': (open('/tmp/test_data/eds_bad.csv', 'rb'), 'eds.csv'),
        'eds_part_col': 'part',
        'value_col': 'value'
    }
    resp = client.post('/api/compare-inv-bal', data=data, content_type='multipart/form-data')
    print('status', resp.status_code)
    print('json', resp.get_json())
PY

------
https://chatgpt.com/codex/tasks/task_e_68882d4674088320a63eaf2cb5faed98