### PR TITLE
Add health endpoint

### DIFF
--- a/backend/main.py
+++ b/backend/main.py
@@ -40,11 +40,17 @@ def handle_exception(e):
     logger.error("[main.py] ❌ Unhandled Exception", exc_info=True)
     return {"error": "Internal server error", "message": str(e)}, 500
 
-# Root health check
+# Root health check at root path
 @app.route('/')
-def health_check():
+def root_health_check():
     logger.info("✅ [main.py] / health check was called.")
     return {'status': 'Python backend is running!'}
+
+# Dedicated /health endpoint used by deployment platforms
+@app.route('/health')
+def health_check():
+    logger.info("✅ [main.py] /health endpoint was called.")
+    return {'status': 'ok'}
 
 if __name__ == '__main__':
     logger.info("🚀 [main.py] Flask server is starting...")


### PR DESCRIPTION
## Summary
- add dedicated `/health` endpoint alongside existing root route

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_688918a835c48320be664b3f8c19a196